### PR TITLE
fix: acceptPatterns settings ignored after restart - always falls back to defaults

### DIFF
--- a/dist/extension.js
+++ b/dist/extension.js
@@ -5442,6 +5442,7 @@ async function activate(context) {
       "chmod -R 777 /"
     ];
     bannedCommands = context.globalState.get(BANNED_COMMANDS_KEY, defaultBannedCommands);
+    acceptPatterns = context.globalState.get("auto-all-accept-patterns", null);
     currentIDE = detectIDE();
     outputChannel = vscode.window.createOutputChannel("auto-all-Antigravity");
     context.subscriptions.push(outputChannel);

--- a/extension.js
+++ b/extension.js
@@ -113,6 +113,7 @@ async function activate(context) {
             'chmod -R 777 /'
         ];
         bannedCommands = context.globalState.get(BANNED_COMMANDS_KEY, defaultBannedCommands);
+        acceptPatterns = context.globalState.get('auto-all-accept-patterns', null);
 
         currentIDE = detectIDE();
 

--- a/main_scripts/full_cdp_script.js
+++ b/main_scripts/full_cdp_script.js
@@ -613,9 +613,11 @@
         if (text.length === 0 || text.length > 100) return false;
 
         // Use configured patterns from state if available, otherwise use defaults
+        // state.acceptPatterns === null means "not configured" → use defaults
+        // state.acceptPatterns === [] means "user deselected everything" → match nothing
         const state = window.__autoAllState || {};
         const defaultPatterns = ['accept', 'accept all', 'run', 'run all', 'run command', 'retry', 'apply', 'execute', 'confirm', 'allow once', 'allow', 'proceed', 'continue', 'yes', 'ok', 'save', 'approve', 'enable', 'install', 'update', 'overwrite'];
-        const patterns = state.acceptPatterns || defaultPatterns;
+        const patterns = state.acceptPatterns !== null && state.acceptPatterns !== undefined ? state.acceptPatterns : defaultPatterns;
         const rejects = ['skip', 'reject', 'cancel', 'close', 'refine', 'deny', 'no', 'dismiss', 'abort', 'ask every time', 'always run', 'always allow', 'always proceed'];
 
         if (rejects.some(r => text.includes(r))) return false;
@@ -920,8 +922,9 @@
 
     window.__autoAllUpdateAcceptPatterns = function (patternList) {
         const state = window.__autoAllState;
-        state.acceptPatterns = Array.isArray(patternList) && patternList.length > 0 ? patternList : null;
-        log(`[Config] Updated accept patterns: ${state.acceptPatterns ? state.acceptPatterns.length + ' patterns' : 'using defaults'}`);
+        // null means "not configured, use defaults"; [] means "user chose nothing"
+        state.acceptPatterns = Array.isArray(patternList) ? patternList : null;
+        log(`[Config] Updated accept patterns: ${state.acceptPatterns !== null ? state.acceptPatterns.length + ' patterns' : 'using defaults'}`);
     };
 
     window.__autoAllGetStats = function () {


### PR DESCRIPTION
## Problem
No matter what auto-accept button settings the user configures, after a restart/reload the extension always auto-clicks **all** button types (including "Proceed" for plans).
## Root Cause
`acceptPatterns` in `extension.js` is initialized as `[]` but **never loaded from `globalState` on startup** (unlike `bannedCommands`, `pollFrequency`, etc.). 
The empty array `[]` is passed to the CDP script, where `__autoAllUpdateAcceptPatterns` converts it to `null` (treating length-0 arrays as "unconfigured"). Then `isAcceptButton` falls back to hardcoded defaults that include every button type.
## Fix
1. **`extension.js`**: Load `acceptPatterns` from `globalState` on activation
2. **`full_cdp_script.js`**: Distinguish `null` (unconfigured → use defaults) from `[]` (user deselected everything → match nothing)  
3. **`full_cdp_script.js`**: Use explicit `null`/`undefined` check instead of falsy `||` for the patterns fallback