### PR TITLE
Fix Antigravity Gemini menu flashing and focus theft (scoped interactions + focus debounce)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to **auto-all-Antigravity** will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Antigravity/Gemini Menu Flashing & Focus Theft**: Hardened `full_cdp_script.js` to fail closed in Antigravity mode unless elements are inside the agent interaction panel. This prevents global menu/toolbar scans from triggering the `Always run` permission dropdown and stealing keyboard focus.
+- **Antigravity Multi-Tab UI Jank (related)**: Restricted Antigravity tab queries/switches to the agent panel instead of broad document scans, reducing accidental UI interactions that amplify flashing and scroll slowdown in `Multi` mode.
+
+### Changed
+
+- **Antigravity Mode Safety Behavior**: Disabled `clickAlwaysRunDropdown()` automation in Antigravity/Gemini mode. Core auto-accept remains active, but the permission dropdown is no longer auto-clicked in this IDE mode to avoid menu flashing regressions.
+
 ## [1.0.28] - 2026-02-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to **auto-all-Antigravity** will be documented in this file.
 ### Changed
 
 - **Antigravity Mode Safety Behavior**: Disabled `clickAlwaysRunDropdown()` automation in Antigravity/Gemini mode. Core auto-accept remains active, but the permission dropdown is no longer auto-clicked in this IDE mode to avoid menu flashing regressions.
+- **Antigravity Focus Stability**: Debounced focus-triggered away-action checks and suppressed away-action toast popups in Antigravity mode to reduce residual keyboard focus theft after the flashing hotfix.
 
 ## [1.0.28] - 2026-02-17
 


### PR DESCRIPTION
## What this fixes

Fixes Antigravity/Gemini-specific UI flashing and keyboard focus theft when `auto-all-AntiGravity` is enabled.

Observed behavior before:
- `ON`: aggressive `Always run` menu flashing + focus theft
- `MULTI`: slower flashing + focus theft + scroll slowdown
- `OFF`: no issue

## Changes

### 1) Scope injected UI automation to the agent panel (`full_cdp_script.js`)
- Added strict panel-scoped querying for Antigravity mode
- Prevented broad document scans for:
  - menu items / dropdowns
  - tab buttons
  - expand controls
- `isInConversationArea(...)` now fails closed in Antigravity mode (no permissive fallback)

### 2) Hotfix: disable `Always run` dropdown automation in Antigravity mode
- Prevents the permission dropdown loop that was visibly flashing and stealing focus
- Core scoped auto-accept behavior remains active

### 3) Reduce residual focus theft (`extension.js`)
- Debounce focus-triggered away-action checks
- Add cooldown throttling for rapid focus events
- Suppress away-action toast popups in Antigravity mode (log only)

## Why this approach

The immediate priority is restoring stable IDE behavior without broad regressions.

This patch intentionally uses a safe hotfix + focus-damping approach:
- stable now
- preserves core automation
- leaves room for a later targeted restoration of `Always run` automation with stronger state checks

## Local validation

- Reproduced issue in Antigravity/Gemini
- Patched source and live-installed extension copy
- Syntax checks passed (`node --check`)
- Manual verification path:
  - reload extension/IDE
  - test `ON`, `MULTI`, `OFF`

## Follow-up (optional)

Re-enable `Always run` automation in Antigravity mode with:
- prompt-state detection
- strict command-card scoping
- idempotent/cooldown guards

## Local commit refs
- `24cbbee` hotfix (panel scoping + disable dropdown automation in Antigravity mode)
- `6ba83f2` follow-up (focus debounce + popup suppression)
